### PR TITLE
fix(babel): build env=prod plugins list by ourselves

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -1,4 +1,4 @@
-module.exports = {
+const config = {
     presets: [
         require('babel-preset-react'),
         require('babel-preset-es2015'),
@@ -7,14 +7,15 @@ module.exports = {
     plugins: [
         require('babel-plugin-transform-decorators-legacy').default,
         [require('babel-plugin-transform-runtime'), { polyfill: false, helpers: false }]
-    ],
-    env: {
-        production: {
-            plugins: [
-                require('babel-plugin-transform-react-remove-prop-types'),
-                require('babel-plugin-transform-react-constant-elements'),
-                require('babel-plugin-transform-react-inline-elements')
-            ]
-        }
-    }
+    ]
 };
+
+if (process.env.NODE_ENV === 'production') {
+    config.plugins.push(
+        require('babel-plugin-transform-react-remove-prop-types').default,
+        require('babel-plugin-transform-react-constant-elements'),
+        require('babel-plugin-transform-react-inline-elements')
+    );
+}
+
+module.exports = config;


### PR DESCRIPTION
По какой то причине старая запись не отрабатывала в prod режиме.
Разбираться не стал, поскольку в 7 версии бабеля это все равно хотят задепрекейтить https://github.com/babel/babel/issues/5276