### PR TITLE
feat(eslint): add jsx-no-target-blank rule

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -64,6 +64,7 @@ module.exports = {
         'react/jsx-filename-extension': [2, { 'extensions': ['.jsx'] }],
         'react/jsx-indent': [2, 4],
         'react/jsx-indent-props': [2, 4],
+        'react/jsx-no-target-blank': true,
         'react/no-unused-prop-types': 0,
         'react/prefer-stateless-function': 0,
         'react/require-default-props': 0,


### PR DESCRIPTION
https://developers.google.com/web/tools/lighthouse/audits/noopener
При использовании target="_blank" новая страница будет запущена тем же процессом что и текущая, что плохо по производительности + у нее будет доступ к location оригинальной страницы `window.opener.location = 'http://fake-bank.com'`