### PR TITLE
feat(webpack): remove ttf and add png to compression plugin regexp

### DIFF
--- a/webpack.production.js
+++ b/webpack.production.js
@@ -35,7 +35,7 @@ module.exports = {
         new CompressionPlugin({
             asset: '[file].gz',
             algorithm: 'gzip',
-            regExp: /\.js$|\.css$|\.ttf$|\.svg$/,
+            regExp: /\.js$|\.css$|\.png$|\.svg$/,
             threshold: 10240,
             minRatio: 0.8
         })


### PR DESCRIPTION
TTF в `arui-feather` больше нет, а PNG был забыт — он используется как минимум в `<Spin />`.