### PR TITLE
feat(webpack): update configs for separated icons css bundle

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -1,13 +1,8 @@
 const path = require('path');
 const webpack = require('webpack');
 
-const FILE_LOADER_QUERY = {
+const QUERY = {
     name: '[name].[hash].[ext]'
-};
-
-const URL_LOADER_QUERY = {
-    name: '[name].[hash].[ext]',
-    limit: 10000
 };
 
 module.exports = {
@@ -26,13 +21,13 @@ module.exports = {
             },
             {
                 test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-                loader: 'url-loader',
-                options: Object.assign({ mimetype: 'application/font-woff' }, URL_LOADER_QUERY)
+                loader: 'file-loader',
+                options: Object.assign({ mimetype: 'application/font-woff' }, QUERY)
             },
             {
                 test: /\.(ttf)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-                loader: 'url-loader',
-                options: Object.assign({ mimetype: 'application/octet-stream' }, URL_LOADER_QUERY)
+                loader: 'file-loader',
+                options: Object.assign({ mimetype: 'application/octet-stream' }, QUERY)
             },
             {
                 test: /\.(eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
@@ -40,23 +35,23 @@ module.exports = {
             },
             {
                 test: /\.(jpe?g)$/i,
-                loader: 'url-loader',
-                options: Object.assign({ mimetype: 'image/jpeg' }, URL_LOADER_QUERY)
+                loader: 'file-loader',
+                options: Object.assign({ mimetype: 'image/jpeg' }, QUERY)
             },
             {
                 test: /\.(gif)$/i,
-                loader: 'url-loader',
-                options: Object.assign({ mimetype: 'image/gif' }, URL_LOADER_QUERY)
+                loader: 'file-loader',
+                options: Object.assign({ mimetype: 'image/gif' }, QUERY)
             },
             {
                 test: /\.(png)$/i,
                 loader: 'file-loader',
-                options: Object.assign({ mimetype: 'image/png' }, FILE_LOADER_QUERY)
+                options: Object.assign({ mimetype: 'image/png' }, QUERY)
             },
             {
                 test: /\.(svg)$/i,
                 loader: 'file-loader',
-                options: Object.assign({ mimetype: 'image/svg+xml' }, FILE_LOADER_QUERY)
+                options: Object.assign({ mimetype: 'image/svg+xml' }, QUERY)
             }
         ]
     },

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -1,7 +1,11 @@
 const path = require('path');
 const webpack = require('webpack');
 
-const ASSETS_BASE_QUERY = {
+const FILE_LOADER_QUERY = {
+    name: '[name].[hash].[ext]'
+};
+
+const URL_LOADER_QUERY = {
     name: '[name].[hash].[ext]',
     limit: 10000
 };
@@ -21,22 +25,14 @@ module.exports = {
                 exclude: /node_modules/
             },
             {
-                test: /\.css$/,
-                use: [
-                    'style-loader',
-                    'css-loader',
-                    'postcss-loader'
-                ]
-            },
-            {
                 test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
                 loader: 'url-loader',
-                options: Object.assign({ mimetype: 'application/font-woff' }, ASSETS_BASE_QUERY)
+                options: Object.assign({ mimetype: 'application/font-woff' }, URL_LOADER_QUERY)
             },
             {
                 test: /\.(ttf)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
                 loader: 'url-loader',
-                options: Object.assign({ mimetype: 'application/octet-stream' }, ASSETS_BASE_QUERY)
+                options: Object.assign({ mimetype: 'application/octet-stream' }, URL_LOADER_QUERY)
             },
             {
                 test: /\.(eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
@@ -45,22 +41,22 @@ module.exports = {
             {
                 test: /\.(jpe?g)$/i,
                 loader: 'url-loader',
-                options: Object.assign({ mimetype: 'image/jpeg' }, ASSETS_BASE_QUERY)
-            },
-            {
-                test: /\.(png)$/i,
-                loader: 'url-loader',
-                options: Object.assign({ mimetype: 'image/png' }, ASSETS_BASE_QUERY)
+                options: Object.assign({ mimetype: 'image/jpeg' }, URL_LOADER_QUERY)
             },
             {
                 test: /\.(gif)$/i,
                 loader: 'url-loader',
-                options: Object.assign({ mimetype: 'image/gif' }, ASSETS_BASE_QUERY)
+                options: Object.assign({ mimetype: 'image/gif' }, URL_LOADER_QUERY)
+            },
+            {
+                test: /\.(png)$/i,
+                loader: 'file-loader',
+                options: Object.assign({ mimetype: 'image/png' }, FILE_LOADER_QUERY)
             },
             {
                 test: /\.(svg)$/i,
-                loader: 'url-loader',
-                options: Object.assign({ mimetype: 'image/svg+xml' }, ASSETS_BASE_QUERY)
+                loader: 'file-loader',
+                options: Object.assign({ mimetype: 'image/svg+xml' }, FILE_LOADER_QUERY)
             }
         ]
     },

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -6,6 +6,18 @@ const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeM
 
 module.exports = {
     devtool: 'inline-eval-source-map',
+    module: {
+        rules: [
+            {
+                test: /\.css$/,
+                use: [
+                    'style-loader',
+                    'css-loader',
+                    'postcss-loader'
+                ]
+            }
+        ]
+    },
     plugins: [
         new CaseSensitivePathsPlugin(),
         new WatchMissingNodeModulesPlugin(path.join(process.cwd(), 'node_modules')),

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -3,15 +3,24 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 
+const extractMainCSS = new ExtractTextPlugin('[name].[hash].css');
+const extractIconsCSS = new ExtractTextPlugin('[name]-icons.[hash].css');
+const extractOptions = {
+    fallback: 'style-loader',
+    use: ['css-loader', 'postcss-loader']
+};
+
 module.exports = {
     module: {
         rules: [
             {
                 test: /\.css$/,
-                loader: ExtractTextPlugin.extract({
-                    fallback: 'style-loader',
-                    use: 'css-loader!postcss-loader'
-                })
+                exclude: /icon.*\.css$/,
+                use: extractMainCSS.extract(extractOptions)
+            },
+            {
+                test: /icon.*\.css$/,
+                use: extractIconsCSS.extract(extractOptions)
             }
         ]
     },
@@ -31,7 +40,8 @@ module.exports = {
             sourceMap: false,
             warnings: false
         }),
-        new ExtractTextPlugin('[name].[hash].css'),
+        extractMainCSS,
+        extractIconsCSS,
         new CompressionPlugin({
             asset: '[file].gz',
             algorithm: 'gzip',


### PR DESCRIPTION
Апдейт webpack конфигов:
1. png/svg кажется лучше подгружать по запросам, нежели хранить в бОльшей по размеру base64 строке
2. разбиение монолитного CSS бандла на основную и иконочную части для подключения последнего асинхронно, без блокирования рендера