### PR TITLE
feat(webpack.base.js): not freeze NODE_ENV

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -60,7 +60,6 @@ module.exports = {
             React: 'react'
         }),
         new webpack.DefinePlugin({
-            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
             'process.HOT_LOADER': process.env.HOT_LOADER
         })
     ]


### PR DESCRIPTION
Значение переменной NODE_ENV не всегда должно фиксироваться во время сборки.
Лучше оставить это на усмотрение проектной команды.

### Объяснение
Значение NODE_ENV часто используется во время сборки для tree shaking и dead code elimination. 

Однако на стороне сервера NODE_ENV может использоваться во время выполнения.
Например, от значения переменой зависит получение облачного конфига на средах integration, prelive, production.

Лучше добавить фиксацию NODE_ENV в stub. Это позволит проектным командам самостоятельно решать, нужно или не нужно фиксировать значение при сборке.