### PR TITLE
fix(package): update babel-eslint to 8.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -609,9 +609,9 @@
       }
     },
     "babel-eslint": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.1.0.tgz",
-      "integrity": "sha512-PoEowcPopVkHl98QPj3ba3iP98I+cAFJXqoJAua23nmw3Qp2m45AJcTQIb5aiqq7Zqi2XjhJuBO1BJDvYCA2Gg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.1.1.tgz",
+      "integrity": "sha512-3oP7pacBIJe2wRiMwr0W7a+1G6rnIUVFqSePXtLayBya2/d1X+KnH1nZfCoS8OXPuuVz5lmJtKrHc8TjDVWK+g==",
       "requires": {
         "@babel/code-frame": "7.0.0-beta.31",
         "@babel/traverse": "7.0.0-beta.31",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@commitlint/config-conventional": "5.1.3",
     "autoprefixer": "7.2.3",
     "babel-core": "6.26.0",
-    "babel-eslint": "8.1.0",
+    "babel-eslint": "8.1.1",
     "babel-loader": "7.1.2",
     "babel-plugin-syntax-dynamic-import": "6.18.0",
     "babel-plugin-transform-class-properties": "6.24.1",


### PR DESCRIPTION
Устранение проблем с обновлением ESLint до 4.14.0:

```
> arui-feather@11.3.1 lint-js /Users/teryaew/Projects/alfa-bank/aruif
> eslint ./*.js ./src/ ./gemini/ ./demo/components --ext .js,.jsx

Cannot read property 'type' of undefined
TypeError: Cannot read property 'type' of undefined
    at isForInRef (/Users/teryaew/Projects/alfa-bank/aruif/node_modules/eslint/lib/rules/no-unused-vars.js:410:24)
    at variable.references.some.ref (/Users/teryaew/Projects/alfa-bank/aruif/node_modules/eslint/lib/rules/no-unused-vars.js:447:21)
    at Array.some (<anonymous>)
    at isUsedVariable (/Users/teryaew/Projects/alfa-bank/aruif/node_modules/eslint/lib/rules/no-unused-vars.js:446:40)
    at collectUnusedVariables (/Users/teryaew/Projects/alfa-bank/aruif/node_modules/eslint/lib/rules/no-unused-vars.js:569:26)
    at collectUnusedVariables (/Users/teryaew/Projects/alfa-bank/aruif/node_modules/eslint/lib/rules/no-unused-vars.js:576:17)
    at Program:exit (/Users/teryaew/Projects/alfa-bank/aruif/node_modules/eslint/lib/rules/no-unused-vars.js:621:36)
    at listeners.(anonymous function).forEach.listener (/Users/teryaew/Projects/alfa-bank/aruif/node_modules/eslint/lib/util/safe-emitter.js:47:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/teryaew/Projects/alfa-bank/aruif/node_modules/eslint/lib/util/safe-emitter.js:47:38)
```

https://github.com/eslint/eslint/issues/9767#issuecomment-353840674