### PR TITLE
fix(*): update babel-eslint to 8.2.1 for resolving export default from

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@commitlint/config-conventional": "5.1.3",
     "autoprefixer": "7.2.4",
     "babel-core": "6.26.0",
-    "babel-eslint": "8.2.0",
+    "babel-eslint": "8.2.1",
     "babel-loader": "7.1.2",
     "babel-plugin-syntax-dynamic-import": "6.18.0",
     "babel-plugin-transform-class-properties": "6.24.1",


### PR DESCRIPTION
Апдейт до `babel-eslint` 8.2.1 чтобы устранить проблему при линтинге:
```
  2:21  error  Parse errors in imported module '../src/sidebar': Line 13: This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom'

> 13 | export default from './sidebar';
     |        ^
```

https://github.com/babel/babel-eslint/pull/571