### PR TITLE
fix(eslint): add some rule about jsx-curly-spacing

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -61,7 +61,7 @@ module.exports = {
         'prefer-arrow-callback': 0,
         'prefer-const': 0,
         'react/jsx-boolean-value': [2, 'always'],
-        'react/jsx-curly-spacing': [2, { 'when': 'always', 'children': true }],
+        'react/jsx-curly-spacing': [2, { when: 'always', children: true }],
         'react/jsx-filename-extension': [2, { extensions: ['.jsx'] }],
         'react/jsx-indent': [2, 4],
         'react/jsx-indent-props': [2, 4],

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -61,7 +61,7 @@ module.exports = {
         'prefer-arrow-callback': 0,
         'prefer-const': 0,
         'react/jsx-boolean-value': [2, 'always'],
-        'react/jsx-curly-spacing': [2, 'always'],
+        'react/jsx-curly-spacing': [2, { 'when': 'always', 'children': true }],
         'react/jsx-filename-extension': [2, { extensions: ['.jsx'] }],
         'react/jsx-indent': [2, 4],
         'react/jsx-indent-props': [2, 4],


### PR DESCRIPTION
Не работали отступы eslint

Можно было писать так:
```jsx
<Hello>{ firstname }</Hello>;
<Hello>{firstname}</Hello>;
<Hello>{
  firstname
}</Hello>;
```