### PR TITLE
feat(postcss): add resolve option

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,16 +99,16 @@
       "eslint"
     ],
     "{babel,babel-node}.js": [
-      "test:babel"
+      "npm run test:babel"
     ],
     "{tslint.js,tsconfig.json}": [
-      "test:tslint"
+      "npm run test:tslint"
     ],
     "postcss.js": [
-      "test:postcss"
+      "npm run test:postcss"
     ],
     "stylelint/*.js": [
-      "test:stylelint"
+      "npm run test:stylelint"
     ]
   },
   "repository": {

--- a/postcss.js
+++ b/postcss.js
@@ -1,10 +1,20 @@
 /* eslint global-require: 0 */
-function getConfig(mq, path = []) {
+
+/**
+ * Формирует конфиг для PostCSS.
+ *
+ * @param {Object} mq https://github.com/postcss/postcss-custom-media#extensions
+ * @param {String|Array} path https://github.com/postcss/postcss-import#path
+ * @param {Function} resolve https://github.com/postcss/postcss-import#resolve
+ * @returns {Object} PostCSS конфиг.
+ */
+function getConfig(mq, path = [], resolve) {
     return {
         plugins: [
             require('postcss-omit-import-tilde')(),
             require('postcss-import')({
                 path,
+                resolve,
                 plugins: [
                     require('postcss-discard-comments')()
                 ]


### PR DESCRIPTION
Добавление опции `resolve` для `postcss-import`.
Необходимо для трансформации импортов при встраивании arui-demo как сабмодуля.
По хорошему счёту нужен более удобный интерфейс для получения гибкого postcss-конфига, но пока предлагаю не ломать совместимость и добавить к существующему.