### PR TITLE
fix(postcss): fix resolve option absence condition

### DIFF
--- a/postcss.js
+++ b/postcss.js
@@ -14,7 +14,8 @@ function getConfig(mq, path = [], resolve) {
             require('postcss-omit-import-tilde')(),
             require('postcss-import')({
                 path,
-                resolve,
+                // Не создаём ключ если resolve нет во входящих аргументах.
+                ...(resolve && { resolve }),
                 plugins: [
                     require('postcss-discard-comments')()
                 ]


### PR DESCRIPTION
Фикс к https://github.com/alfa-laboratory/arui-presets/pull/190.
Иначе `Module build failed: TypeError: options.resolve is not a function`.