### PR TITLE
fix(package): update babel-eslint to version 8.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@commitlint/config-conventional": "6.1.3",
     "autoprefixer": "8.2.0",
     "babel-core": "6.26.0",
-    "babel-eslint": "8.2.2",
+    "babel-eslint": "8.2.3",
     "babel-loader": "7.1.2",
     "babel-plugin-syntax-dynamic-import": "6.18.0",
     "babel-plugin-transform-class-properties": "6.24.1",


### PR DESCRIPTION
Version updated to fix bug with decorators in ona-ao-ui project
```bash
/Users/mike/ap/ona-ao-ui/src/containers/order-list-page/order-list-page.jsx
   5:10  error  'connect' is defined but never used             no-unused-vars
   7:8   error  'cn' is defined but never used                  no-unused-vars
  25:10  error  'mapStateToProps' is defined but never used     no-unused-vars
  34:10  error  'mapDispatchToProps' is defined but never used  no-unused-vars
```