### PR TITLE
fix(*): use shared browserslist config for all tools

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+last 2 versions
+ie >= 10
+Android >= 4
+iOS >= 9

--- a/postcss.js
+++ b/postcss.js
@@ -38,9 +38,7 @@ function getConfig(mq, path = [], resolve) {
             require('postcss-calc')(),
             require('postcss-color-function')(),
             require('postcss-nested')(),
-            require('autoprefixer')({
-                browsers: require('./supporting-browsers')
-            }),
+            require('autoprefixer')(),
             require('postcss-inherit')
         ]
     };

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -1,8 +1,9 @@
+process.env.BROWSERSLIST_CONFIG = process.env.BROWSERSLIST_CONFIG || require.resolve('./.browserslistrc');
+
 const webpack = require('webpack');
 const path = require('path');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
-
 
 module.exports = {
     devtool: 'inline-eval-source-map',

--- a/webpack.production-builder.js
+++ b/webpack.production-builder.js
@@ -1,3 +1,5 @@
+process.env.BROWSERSLIST_CONFIG = process.env.BROWSERSLIST_CONFIG || require.resolve('./.browserslistrc');
+
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');


### PR DESCRIPTION
Общий browserslist для всех тулзов, которые запускаются из вебпака.

Сейчас OptimizeCssAssetsPlugin вырезает префиксы из CSS и компоненты ломаются.

https://github.com/browserslist/browserslist#config-file