### PR TITLE
fix problem with build keyframe names

### DIFF
--- a/webpack.production-builder.js
+++ b/webpack.production-builder.js
@@ -47,7 +47,13 @@ function webpackProductionConfigBuilder(options) {
             }),
             extractMainCSS,
             extractIconsCSS,
-            new OptimizeCssAssetsPlugin(),
+            new OptimizeCssAssetsPlugin({
+                cssProcessorOptions: {
+                    reduceIdents: {
+                        keyframes: false
+                    }
+                }
+            }),
             new CompressionPlugin({
                 asset: '[file].gz',
                 algorithm: 'gzip',


### PR DESCRIPTION
the problem was in keyframe names. when webpack build css it gave the same names for keyframes in different files. So this change fixes it.