### PR TITLE
Added `minimize=true` option to css-loader at webpack production config

### DIFF
--- a/webpack.production-builder.js
+++ b/webpack.production-builder.js
@@ -12,7 +12,10 @@ function webpackProductionConfigBuilder(options) {
     const extractIconsCSS = new ExtractTextPlugin(options.extractIconsCSS || '[name]-icons.[hash].css');
     const extractOptions = Object.assign({
         fallback: require.resolve('style-loader'),
-        use: [require.resolve('css-loader'), require.resolve('postcss-loader')]
+        use: [
+            { loader: 'css-loader', options: { minimize: true } },
+            require.resolve('postcss-loader')
+        ]
     }, options.extractOptions);
 
     return {


### PR DESCRIPTION
Добавлен флаг для минификации css, который через `style-loader` попадает в vendor.js

https://stackoverflow.com/questions/34116379/webpack-extract-text-webpack-plugin-and-css-loader-minification/43348949#43348949