### PR TITLE
chore(readme): change the text in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yarn add arui-presets --dev
 Файл `commitlint.config.js` вашего проекта:
 ```js
 module.exports = {
-    extends: ['arui-presets/commitlint']
+    extends: ['./node_modules/arui-presets/commitlint']
 };
 ```
 


### PR DESCRIPTION
Поменял путь до настроек commitlint'а на относительный, из-за [требований по именованию модуля](https://github.com/marionebl/commitlint#shared-configuration) содержащего внешний конфиг: <img width="852" alt="img" src="https://user-images.githubusercontent.com/37327825/50314641-adf11280-04c0-11e9-9c67-e0b0c762c786.png"> В противном случае commitlint при резолве будет добавлять префикс к имени подключаемого модуля, что приведёт к `сannot find module`: <img width="693" alt="img2" src="https://user-images.githubusercontent.com/37327825/50314448-f825c400-04bf-11e9-8b11-1eedb635aac1.png">